### PR TITLE
Added content-type multipart form data, to correct json error at body…

### DIFF
--- a/public/javascripts/services/multipartForm.service.js
+++ b/public/javascripts/services/multipartForm.service.js
@@ -1,11 +1,11 @@
 export default class multipartForm {
-    //On creation you will need AppConstants and $window
+  //On creation you will need AppConstants and $window
   constructor(AppConstants, $http) {
     'ngInject';
 
     this._$http = $http;
   }
-  
+
   // upload(uploadUrl, data){
   //   console.log('called upload');
   //     var fd = new FormData();
@@ -21,18 +21,28 @@ export default class multipartForm {
   //           } 
   //         )
   // }
-  
-  upload(uploadUrl, data){
+
+  upload(uploadUrl, data) {
     console.log('called upload');
-      var fd = new FormData();
-      for(var key in data){
-          fd.append(key, data[key]);
+    var fd = new FormData();
+    for (var key in data) {
+      fd.append(key, data[key]);
+    }
+    // When you upload a form, you have to change the default content-type to
+    // Multipart/form-data, otherwise it will try to send json
+    // and when you send a form and expect json, body parser will try to 
+    // parse it, which triggers the error before it ever gets to the route itself.
+
+
+    return this._$http.post(uploadUrl, fd, {
+      headers: {
+        'Content-Type': 'multipart/form-data'
       }
-      return this._$http.post(uploadUrl, fd).then(
-             (res) => {
-               return res;
-             } 
-          )
+    }).then(
+      (res) => {
+        return res;
+      }
+    )
   }
 
 


### PR DESCRIPTION
You cannot send form data with content-type:json (which is default in angular 1 unless you manually set it). I changed the serve to include the header with content-type multipart/form-data and it now posts correctly. I did not verify if it actually saved as that was not the original error or issue.